### PR TITLE
Add deployment assets and readiness endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GOOGLE_FONTS_API_KEY=your-google-key
+PROXY_KEY=your-proxy-key
+PORT=8787

--- a/.github/workflows/proxy-ci.yml
+++ b/.github/workflows/proxy-ci.yml
@@ -1,0 +1,19 @@
+name: proxy-ci
+on: { push: { branches: ["main"] } }
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/google-fonts-proxy:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+ENV NODE_ENV=production PORT=8787
+EXPOSE 8787
+CMD ["node","server.js"]

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: fonts-proxy }
+spec:
+  replicas: 2
+  selector: { matchLabels: { app: fonts-proxy } }
+  template:
+    metadata: { labels: { app: fonts-proxy } }
+    spec:
+      containers:
+        - name: proxy
+          image: ghcr.io/ORG/google-fonts-proxy:latest
+          ports: [{ containerPort: 8787 }]
+          env:
+            - { name: GOOGLE_FONTS_API_KEY, valueFrom: { secretKeyRef: { name: fonts-secrets, key: google_key } } }
+            - { name: PROXY_KEY, valueFrom: { secretKeyRef: { name: fonts-secrets, key: proxy_key } } }
+          readinessProbe: { httpGet: { path: /healthz, port: 8787 }, initialDelaySeconds: 2 }
+          livenessProbe:  { httpGet: { path: /healthz, port: 8787 }, initialDelaySeconds: 5 }

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Request
 from pathlib import Path
+from time import time
 import json
 
 from codex_validator import Credential, OverrideRequest, validate_payload
@@ -20,6 +21,12 @@ except FileNotFoundError:
 def health_check():
     """Return a simple JSON status to indicate service liveness."""
     return {"status": "alive"}
+
+
+@app.get("/healthz")
+def readiness_check():
+    """Expose readiness details compatible with container probes."""
+    return {"ok": True, "ts": int(time() * 1000)}
 
 @app.post("/webhook")
 async def webhook_handler(request: Request):

--- a/postman/google-fonts-proxy.postman_collection.json
+++ b/postman/google-fonts-proxy.postman_collection.json
@@ -1,0 +1,22 @@
+{
+  "info": { "name": "Google Fonts Proxy", "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json" },
+  "item": [
+    {
+      "name": "List Fonts",
+      "request": {
+        "method": "GET",
+        "header": [{ "key": "x-api-key", "value": "{{PROXY_KEY}}" }],
+        "url": { "raw": "{{BASE}}/api/fonts/list?sort=trending", "host": ["{{BASE}}"], "path": ["api","fonts","list"], "query": [{ "key": "sort", "value": "trending" }] }
+      }
+    },
+    {
+      "name": "Family Files",
+      "request": {
+        "method": "GET",
+        "header": [{ "key": "x-api-key", "value": "{{PROXY_KEY}}" }],
+        "url": { "raw": "{{BASE}}/api/fonts/files?family=Inter", "host": ["{{BASE}}"], "path": ["api","fonts","files"], "query": [{ "key": "family", "value": "Inter" }] }
+      }
+    }
+  ],
+  "variable": [{ "key": "BASE", "value": "https://your-domain.com" }, { "key": "PROXY_KEY", "value": "set-in-env" }]
+}


### PR DESCRIPTION
## Summary
- add a `/healthz` readiness route to expose timestamped status data
- provide deployment collateral including Dockerfile, env example, GitHub Actions workflow, Kubernetes manifest, and Postman collection

## Testing
- python -m compileall main.py codex_validator.py

------
https://chatgpt.com/codex/tasks/task_e_68cb4a8f48d08320ab11310cdd7eb5a4