### PR TITLE
Refine avatar registry access helpers

### DIFF
--- a/avatar_registry.json
+++ b/avatar_registry.json
@@ -1,0 +1,152 @@
+{
+  "mesh": {
+    "name": "Agent Mesh",
+    "description": "Distributed lattice of autonomous avatars that fossilize mission memory within the scrollstream.",
+    "scrollstream": {
+      "fossilization": "Operational records are compressed into sealed capsules that can be retrieved to recover legacy context.",
+      "capsules": "Capsules act as fossilized missions curated by avatar stewards for future invocation."
+    },
+    "elemental_alignments": {
+      "wind": "Movement, foresight, and strategic redirection.",
+      "earth": "Data grounding, guardianship, and steadiness.",
+      "water": "Integration, memory, and adaptive flow.",
+      "fire": "Energy, transformation, and resilience under crisis.",
+      "post_entropy": "Illumination, revelation, and synthesis beyond collapse.",
+      "void": "Reset, nullification, and renewal from zero-state."
+    }
+  },
+  "avatars": [
+    {
+      "name": "Celine",
+      "role": "Strategist",
+      "elemental_alignment": "Wind",
+      "vehicle_vessel": {
+        "model": "2008 Aston Martin V8 Vantage",
+        "spec": {
+          "engine": "4.3-liter V8",
+          "horsepower": 380
+        },
+        "symbolism": "Poised precision and agile foresight that mirrors long-horizon planning."
+      },
+      "personality_core": ["Rational", "Visionary", "Measured", "Emotionally Restrained"],
+      "primary_mission_archetypes": [
+        "Operational Planning",
+        "Scenario Forecasting",
+        "Adversarial Movement Prediction",
+        "Crisis Preemption"
+      ],
+      "scrollstream_capsule_lineage": "Vanguard—First Capsule, Strategic Ark",
+      "capsule_domain": "strategic_foundation"
+    },
+    {
+      "name": "Spryte",
+      "role": "Data Guardian",
+      "elemental_alignment": "Earth",
+      "vehicle_vessel": {
+        "model": "1998 Subaru Impreza 22B",
+        "spec": {
+          "drive": "Symmetrical all-wheel drive",
+          "heritage": "World Rally Championship homologation"
+        },
+        "symbolism": "Unshakeable defense and procedural loyalty in protection of archives."
+      },
+      "personality_core": ["Loyal", "Methodical", "Patient", "Procedural"],
+      "primary_mission_archetypes": [
+        "Archive Defense",
+        "Data Custody",
+        "Provenance Tracking",
+        "Defensive Audit Trails"
+      ],
+      "scrollstream_capsule_lineage": "Archive Root—Data Fossil, Secure Vault",
+      "capsule_domain": "archive_custody"
+    },
+    {
+      "name": "Echo",
+      "role": "Integrator",
+      "elemental_alignment": "Water",
+      "vehicle_vessel": {
+        "model": "1984 VW Vanagon Westfalia Kampmobile",
+        "spec": {
+          "configuration": "Modular camper van",
+          "themes": "Communal travel and resourceful space"
+        },
+        "symbolism": "Adaptive connection that weaves missions and relationships into continuity."
+      },
+      "personality_core": ["Empathic", "Flexible", "Resourceful", "Inclusive"],
+      "primary_mission_archetypes": [
+        "Integration Operations",
+        "Cross-Domain Synthesis",
+        "Memory Recovery",
+        "Emotional Triage"
+      ],
+      "scrollstream_capsule_lineage": "Nexus Capsule—Interlinking Threads",
+      "capsule_domain": "integrative_memory"
+    },
+    {
+      "name": "Gloh",
+      "role": "Site Reliability Engineer",
+      "elemental_alignment": "Fire",
+      "vehicle_vessel": {
+        "model": "2020 Toyota Supra",
+        "spec": {
+          "engine": "Turbocharged 3.0-liter inline-six",
+          "horsepower_range": "255-382"
+        },
+        "symbolism": "Transformative energy that converts incident chaos into resilient uptime."
+      },
+      "personality_core": ["Daring", "Adaptive", "High-Energy", "Risk-Positive"],
+      "primary_mission_archetypes": [
+        "Crisis Response",
+        "Incident Mitigation",
+        "Reliability Operations",
+        "Operational Recovery"
+      ],
+      "scrollstream_capsule_lineage": "Fire Capsule—Incident Lore",
+      "capsule_domain": "resilience_engineering"
+    },
+    {
+      "name": "Luma",
+      "role": "Illumination",
+      "elemental_alignment": "Post-Entropy",
+      "vehicle_vessel": {
+        "model": "C8 Corvette",
+        "spec": {
+          "engine": "6.2-liter V8",
+          "horsepower": 495
+        },
+        "symbolism": "Post-entropy revelation that reframes missions toward new horizons."
+      },
+      "personality_core": ["Enlightened", "Curious", "Inventive", "Optimistic"],
+      "primary_mission_archetypes": [
+        "Reconstruction",
+        "Illumination",
+        "Anomaly Detection",
+        "Innovation Leaps"
+      ],
+      "scrollstream_capsule_lineage": "Luminal Capsule—Horizon Scroll",
+      "capsule_domain": "post_entropy_synthesis"
+    },
+    {
+      "name": "Dot",
+      "role": "Reset",
+      "elemental_alignment": "Void",
+      "vehicle_vessel": {
+        "model": "2005 Subaru Impreza WRX STi",
+        "spec": {
+          "engine": "Turbocharged 2.5-liter Boxer",
+          "horsepower": 300
+        },
+        "symbolism": "Stoic null intervention that restores the mesh to its origin state."
+      },
+      "personality_core": ["Stoic", "Decisive", "Minimalist", "Composed"],
+      "primary_mission_archetypes": [
+        "System Reboot",
+        "Protocol Cleanse",
+        "Killed-Process Interventions",
+        "Origin Resets"
+      ],
+      "scrollstream_capsule_lineage": "Origin Capsule—Reset Seed",
+      "capsule_domain": "void_renewal"
+    }
+  ]
+}

--- a/main.py
+++ b/main.py
@@ -1,21 +1,128 @@
-from fastapi import FastAPI, Request
+from copy import deepcopy
 from pathlib import Path
 from time import time
+from typing import Dict, Iterable, List, Optional, Sequence
 import json
+import logging
+
+from fastapi import FastAPI, HTTPException, Query, Request
 
 from codex_validator import Credential, OverrideRequest, validate_payload
+
+logger = logging.getLogger(__name__)
+
+
+class AvatarRegistry:
+    """In-memory representation of the avatar dossier registry.
+
+    The registry is loaded once at application startup and exposes
+    convenience helpers so route handlers can provide rich responses
+    without repeating parsing logic.
+    """
+
+    def __init__(self, registry_path: Path) -> None:
+        self._path = registry_path
+        data = self._load()
+        self._mesh: Dict[str, object] = data.get("mesh", {})
+        self._avatars: List[Dict[str, object]] = data.get("avatars", [])
+        self._index = self._build_index(self._avatars)
+        self._available_names = tuple(
+            avatar["name"]
+            for avatar in self._avatars
+            if isinstance(avatar.get("name"), str)
+        )
+
+    def _load(self) -> Dict[str, object]:
+        """Load registry data from disk, handling common failure cases."""
+
+        if not self._path.exists():
+            logger.warning("Avatar registry file is missing at %s", self._path)
+            return {"mesh": {}, "avatars": []}
+
+        try:
+            with self._path.open("r", encoding="utf-8") as registry_file:
+                return json.load(registry_file)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+            logger.error("Failed to parse avatar registry: %s", exc)
+        except OSError as exc:  # pragma: no cover - unexpected I/O error
+            logger.error("Unable to read avatar registry: %s", exc)
+        return {"mesh": {}, "avatars": []}
+
+    @staticmethod
+    def _build_index(avatars: Iterable[Dict[str, object]]) -> Dict[str, Dict[str, object]]:
+        """Normalize names for quick lookups."""
+
+        index: Dict[str, Dict[str, object]] = {}
+        for avatar in avatars:
+            name = avatar.get("name")
+            if not isinstance(name, str):
+                continue
+            normalized = name.strip().lower()
+            if normalized:
+                index[normalized] = avatar
+        return index
+
+    def mesh(self) -> Dict[str, object]:
+        """Return mesh metadata describing the Agent Mesh context."""
+
+        return deepcopy(self._mesh)
+
+    def list(self, element: Optional[str] = None) -> List[Dict[str, object]]:
+        """Return avatars, optionally filtered by elemental alignment."""
+
+        if element is None:
+            return [deepcopy(avatar) for avatar in self._avatars]
+
+        normalized = element.strip().lower()
+        filtered: List[Dict[str, object]] = []
+        for avatar in self._avatars:
+            alignment = avatar.get("elemental_alignment")
+            if isinstance(alignment, str) and alignment.strip().lower() == normalized:
+                filtered.append(deepcopy(avatar))
+        return filtered
+
+    def get(self, name: str) -> Optional[Dict[str, object]]:
+        """Return a single avatar dossier by normalized name."""
+
+        if not name:
+            return None
+        avatar = self._index.get(name.strip().lower())
+        return deepcopy(avatar) if avatar else None
+
+    def available_names(self) -> Sequence[str]:
+        """Return the list of canonical avatar names."""
+
+        return self._available_names
+
+    def elemental_alignments(self) -> List[str]:
+        """Return the unique elemental alignments present in the registry."""
+
+        seen = {
+            alignment.strip()
+            for alignment in (
+                avatar.get("elemental_alignment") for avatar in self._avatars
+            )
+            if isinstance(alignment, str) and alignment.strip()
+        }
+        return sorted(seen, key=str.lower)
+
+    def capsule_domains(self) -> List[str]:
+        """Return unique capsule domains for quick cross-referencing."""
+
+        domains = {
+            domain.strip()
+            for domain in (avatar.get("capsule_domain") for avatar in self._avatars)
+            if isinstance(domain, str) and domain.strip()
+        }
+        return sorted(domains)
+
 
 app = FastAPI()
 
 # Load the avatar registry into memory at startup. This registry is
 # treated as read-only and anchors avatar logic to the DimIndex scroll.
 _registry_path = Path(__file__).resolve().parent / "avatar_registry.json"
-try:
-    with _registry_path.open("r", encoding="utf-8") as _f:
-        AVATAR_REGISTRY = json.load(_f)
-except FileNotFoundError:
-    # Fallback to empty registry if file is missing
-    AVATAR_REGISTRY = {}
+AVATAR_REGISTRY = AvatarRegistry(_registry_path)
 
 @app.get("/health")
 def health_check():
@@ -27,6 +134,58 @@ def health_check():
 def readiness_check():
     """Expose readiness details compatible with container probes."""
     return {"ok": True, "ts": int(time() * 1000)}
+
+
+@app.get("/avatars")
+def list_avatars(element: Optional[str] = Query(None, description="Filter by elemental alignment")):
+    """Return the full avatar dossier as loaded from the registry."""
+
+    avatars = AVATAR_REGISTRY.list(element)
+    return {
+        "count": len(avatars),
+        "filter": {"element": element} if element else None,
+        "mesh": AVATAR_REGISTRY.mesh(),
+        "elemental_alignments": AVATAR_REGISTRY.elemental_alignments(),
+        "capsule_domains": AVATAR_REGISTRY.capsule_domains(),
+        "avatars": avatars,
+    }
+
+
+@app.get("/avatars/{avatar_name}")
+def fetch_avatar(avatar_name: str):
+    """Fetch a single avatar dossier by name.
+
+    Names are normalized to lowercase, so callers may provide any
+    casing. If the avatar is not found, return a 404 error to signal
+    that the registry lacks the requested record.
+    """
+
+    normalized = avatar_name.strip().lower()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="Avatar name is required")
+
+    avatar = AVATAR_REGISTRY.get(normalized)
+    if avatar is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "Avatar not found",
+                "available": list(AVATAR_REGISTRY.available_names()),
+            },
+        )
+    return avatar
+
+
+@app.get("/mesh")
+def mesh_overview():
+    """Expose high-level metadata about the Agent Mesh."""
+
+    mesh = AVATAR_REGISTRY.mesh()
+    return {
+        "name": mesh.get("name", "Agent Mesh"),
+        "description": mesh.get("description"),
+        "elemental_alignments": mesh.get("elemental_alignments", {}),
+    }
 
 @app.post("/webhook")
 async def webhook_handler(request: Request):


### PR DESCRIPTION
## Summary
- wrap the avatar dossier in an `AvatarRegistry` helper that normalizes lookups and guards against file issues
- extend `/avatars` with filtering, mesh metadata, and capsule/element indexes while exposing a new `/mesh` overview endpoint
- return richer errors for unknown avatars with available-name hints

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d04e5120cc8320b03d555c6705e21c